### PR TITLE
adding ability to bulk delete documents by range

### DIFF
--- a/database.go
+++ b/database.go
@@ -280,6 +280,24 @@ func dbwalk(dbname, from, to string, f func(k string, v []byte) error) error {
 	})
 }
 
+func dbwalkKeys(dbname, from, to string, f func(k string) error) error {
+	db, err := dbopen(dbname)
+	if err != nil {
+		log.Printf("Error opening db: %v - %v", dbname, err)
+		return err
+	}
+	defer db.Close()
+
+	return db.Walk(from, func(d *couchstore.Couchstore,
+		di *couchstore.DocInfo) error {
+		if to != "" && di.ID() >= to {
+			return couchstore.StopIteration
+		}
+
+		return f(di.ID())
+	})
+}
+
 func parseKey(s string) int64 {
 	t, err := parseCanonicalTime(s)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -65,6 +65,8 @@ var routingTable []routingEntry = []routingEntry{
 		dbChanges, defaultDeadline},
 	routingEntry{"GET", regexp.MustCompile("^/(" + dbMatch + ")/_query$"),
 		query, *queryTimeout},
+	routingEntry{"DELETE", regexp.MustCompile("^/(" + dbMatch + ")/_bulk$"),
+		deleteBulk, *queryTimeout},
 	routingEntry{"GET", regexp.MustCompile("^/(" + dbMatch + ")/_all"),
 		allDocs, *queryTimeout},
 	routingEntry{"POST", regexp.MustCompile("^/(" + dbMatch + ")/_compact"),


### PR DESCRIPTION
Due to my naivety  about couchdb testing this was confusing at first.  All the docs were still there and my DB was still 54MB.  So - while I did implement deletion, it doesn't seem to be very effective at recovering disk space.  What can we do about that?  Purge?

btw, the syntax is:
DELETE on /dbname/_bulk
accepted querystring parameters are:
from: (starting id to delete)
to: (ending id to delete)
compact: (set to true to run compact after the delete)
