### PR TITLE
add support for ptr=_id to return document id

### DIFF
--- a/query.go
+++ b/query.go
@@ -129,6 +129,9 @@ func processDoc(di *couchstore.DocInfo, chs []chan ptrval,
 
 	for i, p := range ptrs {
 		val := fetched[p]
+		if p == "_id" {
+			val = di.ID()
+		}
 		switch x := val.(type) {
 		case string:
 			pv.val = &x

--- a/query_test.go
+++ b/query_test.go
@@ -196,6 +196,30 @@ func TestNilReducers(t *testing.T) {
 	}
 }
 
+func TestPointers(t *testing.T) {
+	docId := "2013-02-22T16:29:19.750264Z"
+	di := couchstore.NewDocInfo(docId, 0)
+	tests := []struct {
+		pointer string
+		exp     interface{}
+	}{
+		{"/kind", "Listing"},
+		{"_id", docId},
+	}
+
+	for _, test := range tests {
+		chans := make([]chan ptrval, 0, 1)
+		chans = append(chans, make(chan ptrval))
+		go processDoc(di, chans, bigInput, []string{test.pointer}, []string{}, []string{}, true)
+		got := <-chans[0]
+		if test.exp != *got.val {
+			t.Errorf("Expected %v for %v, got %v",
+				test.exp, test.pointer, *got.val)
+		}
+	}
+
+}
+
 func BenchmarkJSONParser(b *testing.B) {
 	b.SetBytes(int64(len(bigInput)))
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This is useful when combined with the identity reducer to return
the list of all document id's that were a part of this group.

For example:

```
/database/_query?ptr=/metric/samplea&reducer=avg&ptr=_id&reducer=identity&group=1000000000
```

This query returns the average value of /metric/samplea and the list of all
document ids in this group.
