### PR TITLE
Complex object support

### DIFF
--- a/query.go
+++ b/query.go
@@ -507,4 +507,36 @@ var reducers = map[string]Reducer{
 		}
 		return rv
 	},
+	"obj_keys": func(input chan ptrval) interface{} {
+		rv := []string{}
+		for v := range input {
+			if v.included {
+				switch value := v.val.(type) {
+				case map[string]interface{}:
+					for mapk, _ := range value {
+						rv = append(rv, mapk)
+					}
+				}
+			}
+		}
+		return rv
+	},
+	"obj_distinct_keys": func(input chan ptrval) interface{} {
+		ukm := map[string]bool{}
+		for v := range input {
+			if v.included {
+				switch value := v.val.(type) {
+				case map[string]interface{}:
+					for mapk, _ := range value {
+						ukm[mapk] = true
+					}
+				}
+			}
+		}
+		rv := make([]string, 0, len(ukm))
+		for k := range ukm {
+			rv = append(rv, k)
+		}
+		return rv
+	},
 }

--- a/query_test.go
+++ b/query_test.go
@@ -166,7 +166,7 @@ func TestEmptyReducers(t *testing.T) {
 }
 
 func TestNilReducers(t *testing.T) {
-	emptyInput := []interface{}{}
+	emptyInput := []interface{}{nil}
 	tests := []struct {
 		reducer string
 		exp     interface{}

--- a/query_test.go
+++ b/query_test.go
@@ -17,7 +17,10 @@ var nextValue = "29"
 var bigInput []byte
 
 func init() {
-	s := []interface{}{"31", "63", "foo", "17"}
+	s := []interface{}{"31", "63", "foo", "17",
+		map[string]interface{}{"key": "value1"},
+		map[string]interface{}{"key": "value2"},
+		map[string]interface{}{"key": "value3"}}
 	for i := range s {
 		testInput = append(testInput, s[i])
 	}
@@ -98,16 +101,18 @@ func TestReducers(t *testing.T) {
 		exp     interface{}
 	}{
 		{"any", "31"},
-		{"count", 4},
+		{"count", 7},
 		{"sum", float64(111)},
 		{"sumsq", float64(5219)},
 		{"max", float64(63)},
 		{"min", float64(17)},
 		{"avg", float64(37)},
 		{"c_min", float64(-23)},
-		{"c_avg", float64(7)},
+		{"c_avg", float64(4)},
 		{"c_max", float64(32)},
 		{"identity", testInput},
+		{"obj_keys", []string{"key", "key", "key"}},
+		{"obj_distinct_keys", []string{"key"}},
 	}
 
 	for _, test := range tests {
@@ -137,6 +142,8 @@ func TestEmptyReducers(t *testing.T) {
 		{"c_avg", math.NaN()},
 		{"c_max", math.NaN()},
 		{"identity", emptyInput},
+		{"obj_keys", []string{}},
+		{"obj_distinct_keys", []string{}},
 	}
 
 	eq := func(a, b interface{}) bool {
@@ -175,6 +182,8 @@ func TestNilReducers(t *testing.T) {
 		{"c_avg", math.NaN()},
 		{"c_max", math.NaN()},
 		{"identity", emptyInput},
+		{"obj_keys", []string{}},
+		{"obj_distinct_keys", []string{}},
 	}
 
 	eq := func(a, b interface{}) bool {

--- a/query_test.go
+++ b/query_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/dustin/go-couchstore"
 )
 
-var testInput = []*string{nil}
+var testInput = []interface{}{}
 var nextValue = "29"
 
 var bigInput []byte
 
 func init() {
-	s := []string{"31", "63", "foo", "17"}
+	s := []interface{}{"31", "63", "foo", "17"}
 	for i := range s {
-		testInput = append(testInput, &s[i])
+		testInput = append(testInput, s[i])
 	}
 
 	var err error
@@ -29,7 +29,7 @@ func init() {
 	}
 }
 
-func streamCollection(s []*string) chan ptrval {
+func streamCollection(s []interface{}) chan ptrval {
 	ch := make(chan ptrval)
 	go func() {
 		defer close(ch)
@@ -41,7 +41,7 @@ func streamCollection(s []*string) chan ptrval {
 		}
 		t = t.Add(time.Second)
 		ts := t.Format(time.RFC3339Nano)
-		ch <- ptrval{couchstore.NewDocInfo(ts, 0), &nextValue, false}
+		ch <- ptrval{couchstore.NewDocInfo(ts, 0), nextValue, false}
 	}()
 	return ch
 }
@@ -74,12 +74,12 @@ func TestPairRateConversion(t *testing.T) {
 	tm := time.Now().UTC()
 	val1 := "20"
 	ch <- ptrval{couchstore.NewDocInfo(tm.Format(time.RFC3339Nano), 0),
-		&val1, true}
+		val1, true}
 
 	tm = tm.Add(5 * time.Second)
 	val2 := "25"
 	ch <- ptrval{couchstore.NewDocInfo(tm.Format(time.RFC3339Nano), 0),
-		&val2, false}
+		val2, false}
 
 	close(ch)
 	exp := 1.0
@@ -121,7 +121,7 @@ func TestReducers(t *testing.T) {
 }
 
 func TestEmptyReducers(t *testing.T) {
-	emptyInput := []*string{}
+	emptyInput := []interface{}{}
 	tests := []struct {
 		reducer string
 		exp     interface{}
@@ -159,7 +159,7 @@ func TestEmptyReducers(t *testing.T) {
 }
 
 func TestNilReducers(t *testing.T) {
-	emptyInput := []*string{nil}
+	emptyInput := []interface{}{}
 	tests := []struct {
 		reducer string
 		exp     interface{}


### PR DESCRIPTION
These commits add the initial infrastructure for handling the case where the JSON pointer matches an array or object.  A lot more functionality can be built on top of this in the future.

In addition to the commit I had you preview the other day, this adds 2 new reducers that work when objects are returned.  I've been using these successfully over the weekend to do some basic schema discovery type operations.
